### PR TITLE
circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 'cimg/ruby:3.0-node'
+      - image: 'cimg/ruby:3.0.0-node'
     steps:
       - checkout
       - ruby/install-deps
       - node/install-packages
   checking:
     docker:
-      - image: 'cimg/ruby:3.0-node'
+      - image: 'cimg/ruby:3.0.0-node'
     steps:
       - checkout
       - ruby/install-deps
@@ -27,7 +27,7 @@ jobs:
           label: Inspecting with Rubocop
   test:
     docker:
-      - image: 'cimg/ruby:3.0-node'
+      - image: 'cimg/ruby:3.0.0-node'
     steps:
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,12 @@ jobs:
       - run:
           name: Install NPM Globals
           command: sudo yarn global add sass gulp-cli
-      - run: gulp
-      - run: bundle install
+      - run:
+          name: Transpiling JavaScript
+          command: gulp scripts
+      - run:
+          name: Running Bundle Install
+          command: bundle install
 
 workflows:
   main_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+# CircleCI pipeline configuration.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  ruby: circleci/ruby@1.8.0
+  node: circleci/node@5.0.2
+
+jobs:
+  build:
+    docker:
+      - image: 'cimg/ruby:3.0-node'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages
+  checking:
+    docker:
+      - image: 'cimg/ruby:3.0-node'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - ruby/rubocop-check:
+          format: progress
+          label: Inspecting with Rubocop
+  test:
+    docker:
+      - image: 'cimg/ruby:3.0-node'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages
+      - ruby/rspec-test:
+          include: spec/**/*_spec.rb
+
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - checking
+      - test:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,31 +15,12 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - node/install-packages
-  checking:
-    docker:
-      - image: 'cimg/ruby:3.0.0-node'
-    steps:
-      - checkout
-      - ruby/install-deps
-      - ruby/rubocop-check:
-          format: progress
-          label: Inspecting with Rubocop
-  test:
-    docker:
-      - image: 'cimg/ruby:3.0.0-node'
-    steps:
-      - checkout
-      - ruby/install-deps
-      - node/install-packages
-      - ruby/rspec-test:
-          include: spec/**/*_spec.rb
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: gulp
+      - run: bundle install
 
 workflows:
-  build_and_test:
+  main_workflow:
     jobs:
       - build
-      - checking
-      - test:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
       - ruby/install-deps
       - node/install-packages:
           pkg-manager: yarn
+      - run:
+          name: Install NPM Globals
+          command: sudo yarn global add sass gulp-cli
       - run: gulp
       - run: bundle install
 

--- a/app/assets/javascript/src/emoji-tetrominos.js
+++ b/app/assets/javascript/src/emoji-tetrominos.js
@@ -1,4 +1,4 @@
-let block = require("./block.js");
+let block = require("./Block.js");
 
 (function(){
 


### PR DESCRIPTION
Adds a Circle-CI config. 

It's still up to you as the owner of the repo to login to circle-ci and click on the "Setup" button and select "Use Existing `.circleci/config.yml`" option.

This will install ruby and node (and yarn). Then install the globals. Then run `bundle install`.

Also found and fixes one issue:
  - renames require to `block.js` to `Block.js` since circle environment was case sensitive on filenames (linux)

